### PR TITLE
fix urlconf: force views import (for gevent)

### DIFF
--- a/django_evercookie/config.py
+++ b/django_evercookie/config.py
@@ -1,8 +1,6 @@
 from django.conf import settings
 from django.contrib.sites.models import Site
 
-current_site = Site.objects.get_current()
-
 class Meta(type):
     def __init__(cls, *args, **kwargs):
         cls.instance = None
@@ -24,7 +22,7 @@ class Settings(object):
              history='false',
              java='false',
              silverlight='false',
-             domain='.'+current_site.domain,
+             domain=None,
              tests=10,
              base_url='',
              auth_path='false',
@@ -43,7 +41,7 @@ class Settings(object):
         self.java = java
         """ Silverlight support """
         self.silverlight = silverlight
-        self.domain = domain
+        self._domain = domain
         """ Max tries to wait / write / read swf, silverlight, png, db and java"""
         self.tests = tests
         """ Base URL for assets, this is Django's STATIC_URL """
@@ -51,5 +49,12 @@ class Settings(object):
         self.auth_path = auth_path
         self.static_url = static_url
         self.cookie_value = cookie_value
+    
+    @property
+    def domain(self):
+        if not self._domain:
+            current_site = Site.objects.get_current()
+            self._domain = ''.join(['.', current_site.domain])
+        return self._domain
 
 settings = Settings()

--- a/django_evercookie/urls.py
+++ b/django_evercookie/urls.py
@@ -3,12 +3,20 @@ try:
 except ImportError:
     from django.conf.urls.defaults import url, patterns
 
+from django_evercookie.views import (
+    evercookie_cache,
+    evercookie_png,
+    evercookie_etag,
+    evercookie_core,
+    evercookie_auth,
+)
 """URLs differ from standart evercookie_<storage_method> to dodge easyprivacy blocking rules"""
 
 
 urlpatterns = patterns('django_evercookie.views',
-    url(r'^ec/cache', 'evercookie_cache', name='ecache'),
-    url(r'^ec/png', 'evercookie_png', name='epng'),
-    url(r'^ec/etag', 'evercookie_etag', name='ecetag'),
-    url(r'^ec/cookie', 'evercookie_core', name='ecookie'),
-    url(r'^ec/auth', 'evercookie_auth', name='ecauth'), )
+    url(r'^ec/cache', evercookie_cache, name='ecache'),
+    url(r'^ec/png', evercookie_png, name='epng'),
+    url(r'^ec/etag', evercookie_etag, name='ecetag'),
+    url(r'^ec/cookie', evercookie_core, name='ecookie'),
+    url(r'^ec/auth', evercookie_auth, name='ecauth'), 
+)


### PR DESCRIPTION
Force views import when importing urlconf to prevent partial module loading under gunicorn/gevent.